### PR TITLE
Add esc; binding for paredit-down-sexp

### DIFF
--- a/paredit.rkt
+++ b/paredit.rkt
@@ -58,7 +58,7 @@
   (let*-when ([dest (get-paredit-backward-sexp ed sp)])
     (send ed set-position dest)))
 
-(define-shortcut ("c:m:d") (paredit-down-sexp ed evt)
+(define-shortcut ("c:m:d" "esc;c:d") (paredit-down-sexp ed evt)
   (send ed down-sexp
         (send ed get-start-position)))
 


### PR DESCRIPTION
paredit-down-sexp is missing esc; binding.

This actually looks too easy to forget. How about we modify define-shortcut macro to automatically process list of key bindings to generate additional esc; variants?
