### PR TITLE
Fix position after paredit-wrap-round

### DIFF
--- a/paredit.rkt
+++ b/paredit.rkt
@@ -122,8 +122,10 @@
 
 (define-shortcut ("m:(") (paredit-wrap-round ed evt)
   (send ed insert "(")
-  (send ed forward-sexp (send ed get-start-position))
-  (send ed insert ")"))
+  (let ([pos (send ed get-start-position)])
+    (send ed forward-sexp pos)
+    (send ed insert ")")
+    (send ed set-position pos)))
 
 (define (first-sexp ed sp)
   (let loop ([pos sp] [prev sp])


### PR DESCRIPTION
Original paredit leaves cursor just after opening parenthesis, which is
extremely useful, as this is essentially where the cursor was before
pressing the key binding module the opening parenthesis. It is also
exactly the position, where you'd add a function name to call on
whatever was just wrapped in parentheses.
